### PR TITLE
Fix admin authentication flow

### DIFF
--- a/app/admin/blog/page.tsx
+++ b/app/admin/blog/page.tsx
@@ -51,13 +51,27 @@ export default function BlogManagement() {
   })
 
   useEffect(() => {
-    const token = localStorage.getItem("admin-token")
-    if (!token) {
-      router.push("/admin/login")
-    } else {
-      setIsAuthenticated(true)
-      loadBlogPosts()
+    const checkAuth = async () => {
+      try {
+        const response = await fetch("/api/auth/verify")
+        if (response.ok) {
+          const data = await response.json()
+          if (data.authenticated && data.user.role === "admin") {
+            setIsAuthenticated(true)
+            loadBlogPosts()
+          } else {
+            router.push("/admin/login")
+          }
+        } else {
+          router.push("/admin/login")
+        }
+      } catch (error) {
+        console.error("Auth check failed:", error)
+        router.push("/admin/login")
+      }
     }
+
+    checkAuth()
   }, [router])
 
   const loadBlogPosts = () => {

--- a/app/admin/brochure/page.tsx
+++ b/app/admin/brochure/page.tsx
@@ -20,13 +20,27 @@ export default function BrochureManagement() {
   const [uploadMessage, setUploadMessage] = useState<{ type: "success" | "error"; text: string } | null>(null)
 
   useEffect(() => {
-    const token = localStorage.getItem("admin-token")
-    if (!token) {
-      router.push("/admin/login")
-    } else {
-      setIsAuthenticated(true)
-      loadBrochure()
+    const checkAuth = async () => {
+      try {
+        const response = await fetch("/api/auth/verify")
+        if (response.ok) {
+          const data = await response.json()
+          if (data.authenticated && data.user.role === "admin") {
+            setIsAuthenticated(true)
+            loadBrochure()
+          } else {
+            router.push("/admin/login")
+          }
+        } else {
+          router.push("/admin/login")
+        }
+      } catch (error) {
+        console.error("Auth check failed:", error)
+        router.push("/admin/login")
+      }
     }
+
+    checkAuth()
   }, [router])
 
   const loadBrochure = () => {

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -24,15 +24,28 @@ export default function AdminLogin() {
     setIsLoading(true)
     setError("")
 
-    // Simulate authentication (replace with real auth)
-    if (email === "admin@junior-miage-concept.fr" && password === "admin123") {
-      localStorage.setItem("admin-token", "authenticated")
-      router.push("/admin/dashboard")
-    } else {
-      setError("Email ou mot de passe incorrect")
-    }
+    try {
+      const response = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email, password }),
+        credentials: "include",
+      })
 
-    setIsLoading(false)
+      if (response.ok) {
+        router.push("/admin/dashboard")
+      } else {
+        const data = await response.json()
+        setError(data.error || "Email ou mot de passe incorrect")
+      }
+    } catch (err) {
+      console.error("Login failed:", err)
+      setError("Erreur de connexion")
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (

--- a/app/admin/partners/page.tsx
+++ b/app/admin/partners/page.tsx
@@ -41,13 +41,27 @@ export default function PartnersManagement() {
   })
 
   useEffect(() => {
-    const token = localStorage.getItem("admin-token")
-    if (!token) {
-      router.push("/admin/login")
-    } else {
-      setIsAuthenticated(true)
-      loadPartners()
+    const checkAuth = async () => {
+      try {
+        const response = await fetch("/api/auth/verify")
+        if (response.ok) {
+          const data = await response.json()
+          if (data.authenticated && data.user.role === "admin") {
+            setIsAuthenticated(true)
+            loadPartners()
+          } else {
+            router.push("/admin/login")
+          }
+        } else {
+          router.push("/admin/login")
+        }
+      } catch (error) {
+        console.error("Auth check failed:", error)
+        router.push("/admin/login")
+      }
     }
+
+    checkAuth()
   }, [router])
 
   const loadPartners = () => {

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -45,13 +45,27 @@ export default function TeamManagement() {
   })
 
   useEffect(() => {
-    const token = localStorage.getItem("admin-token")
-    if (!token) {
-      router.push("/admin/login")
-    } else {
-      setIsAuthenticated(true)
-      loadTeamMembers()
+    const checkAuth = async () => {
+      try {
+        const response = await fetch("/api/auth/verify")
+        if (response.ok) {
+          const data = await response.json()
+          if (data.authenticated && data.user.role === "admin") {
+            setIsAuthenticated(true)
+            loadTeamMembers()
+          } else {
+            router.push("/admin/login")
+          }
+        } else {
+          router.push("/admin/login")
+        }
+      } catch (error) {
+        console.error("Auth check failed:", error)
+        router.push("/admin/login")
+      }
     }
+
+    checkAuth()
   }, [router])
 
   const loadTeamMembers = async () => {


### PR DESCRIPTION
## Summary
- fix login page to call `/api/auth/login`
- check authentication on admin pages using `/api/auth/verify`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d18f9d288327858a47045c1892e1